### PR TITLE
Add pr-merge command to aiops CLI for GitHub and GitLab (closes #520)

### DIFF
--- a/cli/aiops_cli/client.py
+++ b/cli/aiops_cli/client.py
@@ -539,6 +539,23 @@ class APIClient:
             payload["assignee"] = assignee
         return self.post(f"projects/{project_id}/pull-requests", json=payload)
 
+    def git_merge_pr(
+        self,
+        project_id: int,
+        pr_number: int,
+        method: str = "merge",
+        delete_branch: bool = False,
+        commit_message: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Merge a pull request (GitHub) or merge request (GitLab)."""
+        payload = {
+            "method": method,
+            "delete_branch": delete_branch,
+        }
+        if commit_message:
+            payload["commit_message"] = commit_message
+        return self.post(f"projects/{project_id}/pull-requests/{pr_number}/merge", json=payload)
+
     # Workflows
     def workflow_claim_issue(self, issue_id: int) -> dict[str, Any]:
         """Claim issue for work."""


### PR DESCRIPTION
Adds PR/MR merge capability to the aiops CLI for both GitHub and GitLab.

Closes #520

**Backend Changes:**
- Added `/projects/<id>/pull-requests/<number>/merge` API endpoint
- GitHub PR merge support using PyGithub's `pr.merge()` method
- GitLab MR merge support using python-gitlab's `mergerequests.merge()` method
- Provider auto-detection from project integration
- Merge method validation (merge, squash, rebase)

**CLI Changes:**
- Added `aiops git pr-merge <project> <pr-number>` command
- `--method` / `-m`: Choose merge method (merge, squash, rebase) - default: merge
- `--delete-branch`: Delete source branch after merge
- `--message`: Custom merge commit message

**Example Usage:**
```bash
# Merge with defaults (merge commit)
aiops git pr-merge aiops 28

# Squash merge
aiops git pr-merge aiops 28 --method squash

# Merge and delete branch
aiops git pr-merge aiops 28 --delete-branch

# Custom commit message
aiops git pr-merge aiops 28 --message "Fix critical bug"
```

**Testing:**
- CLI command help works correctly
- All merge methods validated
- Provider auto-detection implemented
- Error handling for invalid PR numbers and permissions