### PR TITLE
Fix: allow multiple AI tools per issue session (closes #56)

### DIFF
--- a/app/ai_sessions.py
+++ b/app/ai_sessions.py
@@ -186,6 +186,7 @@ class PersistentAISession:
         session_id: str,
         project_id: int,
         user_id: int,
+        tool: str | None,
         command: str,
         tmux_target: str,
         pipe_file: str,
@@ -194,6 +195,7 @@ class PersistentAISession:
         self.id = session_id
         self.project_id = project_id
         self.user_id = user_id
+        self.tool = tool
         self.command = command
         self.tmux_target = tmux_target
         self.pipe_file = pipe_file
@@ -431,10 +433,11 @@ def find_session_for_issue(
                     continue
 
                 matches_tool = True
-                if expected_tool is not None and session.tool is not None:
-                    matches_tool = session.tool == expected_tool
-                if session.tool is None and expected_tool is not None:
-                    matches_tool = True
+                if expected_tool is not None:
+                    if getattr(session, "tool", None) is None:
+                        matches_tool = False
+                    else:
+                        matches_tool = session.tool == expected_tool
 
                 matches_command = True
                 if expected_command is not None and session.command is not None:
@@ -1046,6 +1049,7 @@ def create_persistent_session(
         session_id,
         project.id,
         user_id,
+        tool,
         command_str,
         tmux_target_full,
         pipe_file,

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -13,11 +13,13 @@ from sqlalchemy.orm import selectinload
 from ..ai_sessions import (
     close_session,
     create_session,
+    find_session_for_issue,
     get_session,
     find_session_for_issue,
     _resolve_command,
     resize_session,
     write_to_session,
+    _resolve_command,
 )
 from ..constants import DEFAULT_TENANT_COLOR, sanitize_tenant_color
 from ..extensions import csrf, db
@@ -546,7 +548,7 @@ def start_project_ai_session(project_id: int):
     resolved_command = None
 
     try:
-        resolved_command = _resolve_command(tool, command)
+        resolved_command = _resolve_command(tool, command, permission_mode=permission_mode)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 


### PR DESCRIPTION
Fixes issue session reuse so a second AI tool in the same project/issue doesn't get forced onto the first tool.\n\nCloses #56\n\nChanges:\n- store tool on persistent sessions and require tool/command match before reusing an issue session\n- resolve the launch command when checking for reuse to match the actual tool command\n- add regression test for persistent session reuse respecting tool\n\nTesting:\n- .venv/bin/pytest tests/test_ai_sessions.py::test_find_session_for_issue_respects_tool_for_persistent