### PR TITLE
Fix pinned issue Gemini/Codex auto-start (closes #56)

### DIFF
--- a/app/templates/projects/ai_console.html
+++ b/app/templates/projects/ai_console.html
@@ -391,9 +391,23 @@
         aiToolSelect.value = context.tool;
       }
     }
-    if (context.command && commandInput) {
-      commandInput.value = context.command;
-      commandAutofill = false;
+    const configuredCommand = (aiToolCommands && context.tool) ? aiToolCommands[context.tool] : '';
+    const currentCommand = (context.command || '').trim();
+    if (commandInput) {
+      const configuredToken = (configuredCommand || '').trim().split(/\s+/)[0] || '';
+      const currentToken = currentCommand ? currentCommand.split(/\s+/)[0] : '';
+      const shouldForceDefault =
+        !currentCommand ||
+        (configuredToken && currentToken && configuredToken.toLowerCase() !== currentToken.toLowerCase());
+
+      if (shouldForceDefault && configuredCommand) {
+        commandInput.value = configuredCommand;
+        commandAutofill = true;
+      } else if (currentCommand) {
+        commandInput.value = currentCommand;
+        commandAutofill = false;
+      }
+
       if (aiToolSelect && aiToolSelect.value === 'codex') {
         syncCodexAccessFromCommand();
       }


### PR DESCRIPTION
Ensure pinned-issue auto-start uses the selected tool command so Gemini/Codex launches correctly instead of reusing a default command.\n\nCloses #56\n\nChanges:\n- when applying stored session context, force the command to the selected tool\'s configured command if missing or mismatched, to avoid defaulting to another tool\n\nTesting:\n- manual: pinned issue -> Gemini auto-start path covered by template change