### PR TITLE
Fix pinned auto-start when tool option missing (closes #56)

### DIFF
--- a/app/templates/projects/ai_console.html
+++ b/app/templates/projects/ai_console.html
@@ -206,6 +206,7 @@
   const codexAccessValues = new Set(['never', 'on-failure']);
   const sessionStorageKey = `aiops-session-context-${projectId}`;
   let storedSessionContext = null;
+  let storedContextTool = null;
   let plannedPrompt = '';
   let pendingPrompt = false;
   let commandAutofill = true;
@@ -385,6 +386,7 @@
       return false;
     }
     storedSessionContext = context;
+    storedContextTool = context.tool || null;
     if (context.tool && aiToolSelect) {
       const optionExists = Array.from(aiToolSelect.options).some(opt => opt.value === context.tool);
       if (optionExists) {
@@ -668,7 +670,7 @@
   function startSession(options = {}) {
     const { tmuxTargetOverride } = options;
     const attachOnly = Boolean(tmuxTargetOverride);
-    const tool = aiToolSelect.value;
+    const tool = (aiToolSelect && aiToolSelect.value) || storedContextTool || '';
     const command = commandInput.value.trim();
     const selectedTmuxTarget = attachOnly
       ? tmuxTargetOverride


### PR DESCRIPTION
Ensure pinned issue auto-start honors the requested tool even if the dropdown lacks that option by using the stored tool in session context. Prevents falling back to another tool's command when launching Gemini/Codex via pinned issues.\n\nCloses #56\n\nChanges:\n- track stored tool from pinned-context and use it when the select has no matching option\n- require startSession to fall back to stored tool when dropdown is empty\n\nTesting:\n- manual: pinned issue -> Gemini auto-start path