### PR TITLE
Enable file upload to AI session workspace (refs #73)

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -11,6 +11,7 @@ from flask import Blueprint, current_app, g, jsonify, request
 from flask_login import current_user  # type: ignore
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
+from werkzeug.utils import secure_filename
 
 from ..ai_sessions import (
     close_session,
@@ -31,6 +32,7 @@ from ..services.tmux_service import session_name_for_user
 from ..services.issues.utils import normalize_issue_status
 from ..services.activity_logger import log_api_activity, log_git_operation, log_session_operation
 from ..services.activity_service import ActivityType, ResourceType
+from ..services.workspace_service import get_workspace_path
 
 api_bp = Blueprint("api", __name__, url_prefix="/api/v1")
 
@@ -782,6 +784,80 @@ def send_project_ai_input(project_id: int, session_id: str):
 
     write_to_session(session, text)
     return jsonify({"status": "ok"})
+
+
+@api_bp.post("/projects/<int:project_id>/ai/sessions/<session_id>/upload")
+def upload_file_to_session(project_id: int, session_id: str):
+    """Upload a file to the session's workspace .uploads directory.
+
+    Args:
+        project_id: Project ID
+        session_id: Session ID
+
+    Request:
+        multipart/form-data with 'file' field
+
+    Returns:
+        200: File uploaded successfully with workspace path
+        400: Invalid request (no file, file too large, etc.)
+        403: Access denied
+        404: Session not found
+    """
+    session, error_response, status = _get_project_session(project_id, session_id)
+    if error_response is not None:
+        return error_response, status
+
+    # Check if file is in request
+    if 'file' not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files['file']
+    if not file or not file.filename:
+        return jsonify({"error": "No file selected"}), 400
+
+    # Get project and user for workspace path
+    project = Project.query.get_or_404(project_id)
+    user = User.query.get(session.user_id)
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    # Get workspace path
+    workspace_path = get_workspace_path(project, user)
+    if not workspace_path:
+        return jsonify({"error": "Workspace not initialized for user"}), 400
+
+    # Create .uploads directory
+    uploads_dir = workspace_path / ".uploads"
+    try:
+        uploads_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        current_app.logger.error(f"Failed to create uploads directory: {exc}")
+        return jsonify({"error": "Failed to create uploads directory"}), 500
+
+    # Secure filename
+    filename = secure_filename(file.filename)
+    if not filename:
+        return jsonify({"error": "Invalid filename"}), 400
+
+    # Save file
+    file_path = uploads_dir / filename
+    try:
+        file.save(str(file_path))
+        file_size = file_path.stat().st_size
+    except Exception as exc:
+        current_app.logger.error(f"Failed to save file: {exc}")
+        return jsonify({"error": "Failed to save file"}), 500
+
+    # Return workspace path (relative to workspace root for user convenience)
+    relative_path = f".uploads/{filename}"
+
+    return jsonify({
+        "message": "File uploaded successfully",
+        "workspace_path": str(file_path),
+        "relative_path": relative_path,
+        "filename": filename,
+        "size": file_size
+    }), 200
 
 
 @api_bp.post("/projects/<int:project_id>/ai/sessions/<session_id>/resize")

--- a/cli/aiops_cli/cli.py
+++ b/cli/aiops_cli/cli.py
@@ -2218,6 +2218,98 @@ def sessions_kill(
         sys.exit(1)
 
 
+@sessions.command(name="upload")
+@click.argument("session_id")
+@click.argument("file_path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--name", help="Custom filename in workspace (defaults to original)")
+@click.option("--project", help="Filter by project ID or name")
+@click.pass_context
+def sessions_upload(
+    ctx: click.Context,
+    session_id: str,
+    file_path: str,
+    name: Optional[str],
+    project: Optional[str],
+) -> None:
+    """Upload file to session workspace.
+
+    The file will be placed in .uploads/ directory in the session's workspace,
+    making it accessible to the AI for analysis.
+
+    Examples:
+        aiops sessions upload abc123 screenshot.png
+        aiops sessions upload abc123 error.log --name debug.log
+        aiops sessions upload abc123 diagram.pdf --project aiops
+    """
+    client = get_client(ctx)
+
+    try:
+        # Find the session to get project_id
+        all_users = client.is_admin()
+        project_id = resolve_project_id(client, project) if project else None
+
+        all_sessions = client.list_all_sessions(
+            project_id=project_id,
+            all_users=all_users,
+            active_only=True,
+            limit=200,
+        )
+
+        if not all_sessions:
+            error_console.print("[red]Error:[/red] No active sessions found")
+            sys.exit(1)
+
+        # Find matching session
+        identifier = session_id.strip()
+        if identifier.endswith("..."):
+            identifier = identifier[:-3]
+
+        target_session = None
+        for session in all_sessions:
+            sid = str(session.get("session_id", ""))
+            if identifier and (sid == identifier or sid.startswith(identifier)):
+                target_session = session
+                break
+
+        if not target_session:
+            error_console.print(
+                f"[red]Error:[/red] Session '{session_id}' not found"
+            )
+            sys.exit(1)
+
+        # Get session details
+        session_project_id = target_session.get("project_id")
+        full_session_id = target_session.get("session_id")
+        tool = target_session.get("tool", "unknown")
+
+        if not session_project_id or not full_session_id:
+            error_console.print("[red]Error:[/red] Session missing required information")
+            sys.exit(1)
+
+        # Upload file
+        console.print(f"[cyan]Uploading {file_path}...[/cyan]")
+        result = client.upload_session_file(
+            session_project_id, full_session_id, file_path, custom_name=name
+        )
+
+        # Display success
+        console.print(f"\n[green]✓ File uploaded successfully![/green]")
+        console.print(f"  Workspace path: {result['workspace_path']}")
+        console.print(f"  Relative path: {result['relative_path']}")
+        console.print(f"  Size: {result['size'] / 1024:.1f} KB")
+        console.print(f"\n[dim]The AI can now access this file in the session.[/dim]")
+
+    except APIError as exc:
+        error_console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
+    except FileNotFoundError:
+        error_console.print(f"[red]Error:[/red] File not found: {file_path}")
+        sys.exit(1)
+    except Exception as exc:
+        error_console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
+
+
 # ============================================================================
 # TENANTS COMMANDS
 # ============================================================================


### PR DESCRIPTION
## Summary

Implements CLI command to upload files from local machine to AI session workspace, enabling users to transfer screenshots, PDFs, and other files to running AI sessions for analysis.

**Command syntax:**
```bash
aiops sessions upload <session-id> <file-path> [--name <custom-name>]
```

## Implementation

### Backend API Endpoint
- **Route:** `POST /api/v1/projects/<project_id>/ai/sessions/<session_id>/upload`
- Validates session access and ownership
- Creates `.uploads/` directory in session workspace
- Saves uploaded file with `secure_filename()` sanitization
- Returns workspace path, relative path, filename, and size

### CLI Client
- Added `upload_session_file()` method to APIClient
- Added `_upload_request()` helper for multipart/form-data uploads
- Supports custom filename via `--name` option

### CLI Command
- `aiops sessions upload` command with session lookup
- Supports partial session ID matching (e.g., "abc..." matches "abc123...")
- User-friendly output showing file location and size

## File Storage

Files are saved to `<workspace>/.uploads/<filename>`, accessible to AI sessions at:
```
/home/{username}/workspace/{tenant}/{project}/.uploads/
```

## Examples

```bash
# Upload screenshot
aiops sessions upload abc123 screenshot.png

# Upload with custom name
aiops sessions upload abc123 error.log --name debug.log

# Upload to specific project session
aiops sessions upload abc123 diagram.pdf --project aiops
```

## Testing

- ✅ File save logic verified (creates .uploads/, correct permissions)
- ✅ Workspace path logic validated
- ✅ secure_filename() prevents path traversal
- ⏸️ End-to-end API testing pending deployment

## Related

- Closes #73
- Replaces wrong implementation from PR #74 (closed)