### PR TITLE
Fix AI-assisted issue structuring (closes #77)

### DIFF
--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -621,4 +621,4 @@ class AIAssistedIssueForm(FlaskForm):
         "Pin issue to dashboard",
         default=False,
     )
-    submit = SubmitField("Create Draft Issue & Start AI Session")
+    submit = SubmitField("Create Issue & Start AI Session")

--- a/app/templates/admin/create_assisted_issue.html
+++ b/app/templates/admin/create_assisted_issue.html
@@ -118,7 +118,7 @@
           <div class="checkbox-group">
             <label class="checkbox-label">
               {{ form.create_branch() }}
-              <span>Create feature/fix branch after formatting</span>
+              <span>Create feature/fix branch after structuring the issue</span>
             </label>
             <label class="checkbox-label">
               {{ form.pin_issue() }}
@@ -130,7 +130,7 @@
 
       <div class="form-actions">
         <button type="submit" class="primary">
-          <span class="submit-text">Create Draft Issue & Start AI Session</span>
+          <span class="submit-text">Create Issue & Start AI Session</span>
         </button>
         <a href="{{ url_for('admin.manage_issues') }}" role="button" class="secondary outline">Cancel</a>
       </div>


### PR DESCRIPTION
Fixes AI-assisted issue creation so AI output is structured and persisted correctly.

Changes:
- Use generated issue content in admin and API assisted creation and persist payload/comments
- Fix branch creation call and update UI copy to reflect real issue creation
- Add regression test for structured assisted issues

Testing:
- .venv/bin/pytest tests/test_admin_issues.py::test_ai_assisted_issue_uses_structured_content