### PR TITLE
Add assignee filtering to issues list command

### DIFF
--- a/cli/aiops_cli/cli.py
+++ b/cli/aiops_cli/cli.py
@@ -351,6 +351,7 @@ def issues_pinned(ctx: click.Context, output: Optional[str]) -> None:
 @click.option("--status", help="Filter by status (open, closed)")
 @click.option("--provider", help="Filter by provider (github, gitlab, jira)")
 @click.option("--project", help="Filter by project ID or name")
+@click.option("--assignee", help="Filter by assignee name")
 @click.option("--limit", type=int, help="Limit number of results")
 @click.option("--output", "-o", type=click.Choice(["table", "json", "yaml"]), help="Output format")
 @click.pass_context
@@ -359,6 +360,7 @@ def issues_list(
     status: Optional[str],
     provider: Optional[str],
     project: Optional[str],
+    assignee: Optional[str],
     limit: Optional[int],
     output: Optional[str],
 ) -> None:
@@ -377,6 +379,7 @@ def issues_list(
             status=status,
             provider=provider,
             project_id=project_id,
+            assignee=assignee,
             limit=limit,
         )
         # Show only the most relevant columns for list view

--- a/cli/aiops_cli/client.py
+++ b/cli/aiops_cli/client.py
@@ -193,6 +193,7 @@ class APIClient:
         status: Optional[str] = None,
         provider: Optional[str] = None,
         project_id: Optional[int] = None,
+        assignee: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> list[dict[str, Any]]:
         """List issues."""
@@ -203,6 +204,8 @@ class APIClient:
             params["provider"] = provider
         if project_id:
             params["project_id"] = project_id
+        if assignee:
+            params["assignee"] = assignee
         if limit:
             params["limit"] = limit
         data = self.get("issues", params=params)


### PR DESCRIPTION
## Summary
- Adds `--assignee` option to `aiops issues list` command
- Updates CLI client to pass assignee parameter to API
- Backend already supports assignee filtering

## Usage
```bash
aiops issues list --assignee "Michael Turko"
aiops issues list --assignee "Ivo Marino" --status open
```

## Testing
- CLI command accepts the new --assignee option
- Parameter is correctly passed to the API endpoint
- Backend filtering logic is already implemented

Closes #81