### PR TITLE
Simplify Codex auth: use system credentials like Claude

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2303,7 +2303,7 @@ def create_assisted_issue():
             # Let the AI structure the issue before creation
             try:
                 issue_data = generate_issue_from_description(
-                    description, ai_tool, issue_type, user_id=current_user.id
+                    description, ai_tool, issue_type
                 )
             except AIIssueGenerationError as exc:
                 flash(f"AI generation failed: {exc}", "error")

--- a/app/routes/api_v1/issues.py
+++ b/app/routes/api_v1/issues.py
@@ -1018,15 +1018,10 @@ def create_assisted_issue():
     if not integration or integration.project_id != project_id:
         return jsonify({"error": f"Integration {integration_id} not found for project"}), 404
 
-    # Get current user ID for AI tool authentication
-    current_user_id = g.current_user.id if hasattr(g, "current_user") else None
-
     try:
         # Step 1: Generate issue content using AI
         try:
-            issue_data = generate_issue_from_description(
-                description, ai_tool, issue_type, user_id=current_user_id
-            )
+            issue_data = generate_issue_from_description(description, ai_tool, issue_type)
         except AIIssueGenerationError as e:
             return jsonify({
                 "error": "AI generation failed",
@@ -1036,7 +1031,7 @@ def create_assisted_issue():
         # Step 2: Create the issue and persist it locally
         try:
             # Pass creator_user_id to ensure issue is created with correct user's credentials
-            creator_user_id = current_user_id
+            creator_user_id = g.current_user.id if hasattr(g, "current_user") else None
             issue_payload = create_issue_for_project_integration(
                 project_integration=integration,
                 summary=issue_data["title"],

--- a/app/services/ai_issue_generator.py
+++ b/app/services/ai_issue_generator.py
@@ -7,15 +7,12 @@ issues from natural language descriptions using AI tools like Claude.
 from __future__ import annotations
 
 import json
-import os
 import re
 import shlex
 import subprocess
 from typing import Any
 
 from flask import current_app
-
-from .codex_config_service import CodexConfigError, ensure_codex_auth
 
 
 class AIIssueGenerationError(Exception):
@@ -26,7 +23,6 @@ def generate_issue_from_description(
     description: str,
     ai_tool: str = "claude",
     issue_type: str | None = None,
-    user_id: int | None = None,
 ) -> dict[str, Any]:
     """Generate a structured issue from a natural language description.
 
@@ -34,7 +30,6 @@ def generate_issue_from_description(
         description: Natural language description of what the user wants to work on
         ai_tool: AI tool to use for generation (claude, codex, gemini)
         issue_type: Optional hint about issue type (feature, bug, etc.)
-        user_id: User ID for authentication (required for codex)
 
     Returns:
         Dictionary with:
@@ -98,30 +93,12 @@ Rules:
             if not any(token in {"exec", "e"} for token in codex_command[1:]):
                 codex_command.append("exec")
 
-            # Set up Codex authentication environment
-            codex_env = os.environ.copy()
-            if user_id is not None:
-                try:
-                    cli_auth_path = ensure_codex_auth(user_id)
-                    codex_env["CODEX_CONFIG_DIR"] = str(cli_auth_path.parent)
-                    codex_env["CODEX_AUTH_FILE"] = str(cli_auth_path)
-                except CodexConfigError as exc:
-                    raise AIIssueGenerationError(
-                        f"Codex authentication failed: {exc}. "
-                        "Please configure Codex credentials in Settings."
-                    ) from exc
-            else:
-                current_app.logger.warning(
-                    "Codex called without user_id; authentication may fail"
-                )
-
             result = subprocess.run(
                 codex_command + [prompt],
                 capture_output=True,
                 text=True,
                 timeout=30,
                 check=False,
-                env=codex_env,
             )
         elif ai_tool == "gemini":
             # For Gemini

--- a/tests/test_ai_issue_generator.py
+++ b/tests/test_ai_issue_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import subprocess
 from pathlib import Path
 
@@ -8,11 +7,7 @@ import pytest
 
 from app import create_app
 from app.config import Config
-from app.services.ai_issue_generator import (
-    AIIssueGenerationError,
-    generate_issue_from_description,
-)
-from app.services.codex_config_service import save_codex_auth
+from app.services.ai_issue_generator import generate_issue_from_description
 
 
 def _build_app(tmp_path: Path, codex_command: str):
@@ -22,7 +17,6 @@ def _build_app(tmp_path: Path, codex_command: str):
         SQLALCHEMY_DATABASE_URI = "sqlite://"
         REPO_STORAGE_PATH = str(tmp_path / "repos")
         ALLOWED_AI_TOOLS = {"codex": codex_command}
-        CODEX_CONFIG_DIR = str(tmp_path / ".codex")
 
     instance_dir = tmp_path / "instance"
     instance_dir.mkdir(parents=True, exist_ok=True)
@@ -40,9 +34,8 @@ def test_codex_exec_used_for_issue_generation(monkeypatch, tmp_path, codex_comma
     """Ensure we call codex with the exec subcommand (no legacy query)."""
     calls: dict = {}
 
-    def fake_run(cmd, capture_output, text, timeout, check, env=None):
+    def fake_run(cmd, capture_output, text, timeout, check):
         calls["cmd"] = cmd
-        calls["env"] = env
         return subprocess.CompletedProcess(
             cmd,
             0,
@@ -65,57 +58,3 @@ def test_codex_exec_used_for_issue_generation(monkeypatch, tmp_path, codex_comma
     assert "query" not in cmd
     assert cmd[-1].startswith("You are helping a developer")
     assert issue_data["branch_prefix"] == "fix"
-
-
-def test_codex_authentication_env_set_when_user_id_provided(monkeypatch, tmp_path):
-    """Ensure CODEX_CONFIG_DIR and CODEX_AUTH_FILE are set when user_id is provided."""
-    calls: dict = {}
-
-    def fake_run(cmd, capture_output, text, timeout, check, env=None):
-        calls["cmd"] = cmd
-        calls["env"] = env
-        return subprocess.CompletedProcess(
-            cmd,
-            0,
-            stdout='{"title":"T","description":"D","labels":["bug"],"branch_prefix":"fix"}',
-            stderr="",
-        )
-
-    monkeypatch.setattr("app.services.ai_issue_generator.subprocess.run", fake_run)
-
-    app = _build_app(tmp_path, "codex")
-    with app.app_context():
-        # Save codex auth for user 42
-        save_codex_auth(json.dumps({"token": "test-token"}), user_id=42)
-
-        issue_data = generate_issue_from_description(
-            "test description",
-            ai_tool="codex",
-            issue_type="bug",
-            user_id=42,
-        )
-
-    env = calls["env"]
-    assert env is not None
-    assert "CODEX_CONFIG_DIR" in env
-    assert "CODEX_AUTH_FILE" in env
-    assert ".codex" in env["CODEX_CONFIG_DIR"]
-    assert "auth.json" in env["CODEX_AUTH_FILE"]
-    assert issue_data["title"] == "T"
-
-
-def test_codex_auth_failure_raises_ai_issue_generation_error(tmp_path):
-    """Ensure CodexConfigError is wrapped in AIIssueGenerationError."""
-    app = _build_app(tmp_path, "codex")
-    with app.app_context():
-        # User 999 has no saved credentials
-        with pytest.raises(AIIssueGenerationError) as exc_info:
-            generate_issue_from_description(
-                "test description",
-                ai_tool="codex",
-                issue_type="bug",
-                user_id=999,
-            )
-
-        assert "Codex authentication failed" in str(exc_info.value)
-        assert "configure Codex credentials" in str(exc_info.value)


### PR DESCRIPTION
Remove per-user Codex credential injection since Codex CLI now uses system-level authentication (same as Claude).

refs #102