### PR TITLE
Fix Codex authentication in AI-assisted issue creation (closes #102)

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2306,7 +2306,7 @@ def create_assisted_issue():
             # Let the AI structure the issue before creation
             try:
                 issue_data = generate_issue_from_description(
-                    description, ai_tool, issue_type
+                    description, ai_tool, issue_type, user_id=current_user.id
                 )
             except AIIssueGenerationError as exc:
                 flash(f"AI generation failed: {exc}", "error")

--- a/tests/test_admin_issues.py
+++ b/tests/test_admin_issues.py
@@ -348,8 +348,8 @@ def test_ai_assisted_issue_uses_structured_content(
     calls: dict[str, Any] = {}
     structured_body = "Structured body with sections"
 
-    def fake_generate(description, ai_tool, issue_type):
-        calls["generate"] = (description, ai_tool, issue_type)
+    def fake_generate(description, ai_tool, issue_type, user_id=None):
+        calls["generate"] = (description, ai_tool, issue_type, user_id)
         return {
             "title": "Structured Issue Title",
             "description": structured_body,
@@ -438,7 +438,7 @@ def test_ai_assisted_issue_uses_structured_content(
     )
 
     assert response.status_code == 302
-    assert calls["generate"] == ("build structured issue", "claude", "feature")
+    assert calls["generate"] == ("build structured issue", "claude", "feature", user_id)
     assert calls["create_issue"]["summary"] == "Structured Issue Title"
     assert calls["create_issue"]["description"] == structured_body
     assert calls["create_issue"]["labels"] == ["ai-generated", "feature"]


### PR DESCRIPTION
## Summary

Fixes the Codex authentication error when creating AI-assisted issues.

Closes #102

## Problem

When creating an AI-assisted issue with Codex as the AI tool, the generation failed with:

```
ERROR: Your access token could not be refreshed because your refresh token was already used.
```

The `generate_issue_from_description()` function was running `codex exec` without setting up proper authentication environment variables.

## Solution

- Added `user_id` parameter to `generate_issue_from_description()`
- Set up Codex authentication using `ensure_codex_auth(user_id)` before running subprocess
- Pass `CODEX_CONFIG_DIR` and `CODEX_AUTH_FILE` environment variables to subprocess
- Applied same pattern for Gemini authentication
- Updated caller in `app/routes/admin.py` to pass `current_user.id`
- Updated tests to match new function signature

## Testing

- All tests pass including `test_ai_issue_generator.py` and `test_admin_issues.py`
- Verified authentication environment is properly set up in subprocess calls
- No new lint errors introduced