### PR TITLE
Feature: Convert Tenants page to thread-style format

### DIFF
--- a/app/templates/admin/tenants.html
+++ b/app/templates/admin/tenants.html
@@ -5,7 +5,7 @@
   <style>
     .tenants-layout {
       display: grid;
-      gap: 2rem;
+      gap: 1.5rem;
     }
     .tenants-section {
       display: flex;
@@ -27,62 +27,42 @@
       padding: 0.25rem 0.75rem;
     }
     .tenants-card-list {
-      display: none;
-      gap: 1rem;
-      margin-top: 1rem;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    }
-    .tenant-card {
-      border: 1px solid rgba(148, 163, 184, 0.3);
-      border-radius: 1rem;
-      padding: 1rem 1.2rem;
-      background: rgba(255, 255, 255, 0.86);
-    }
-    [data-theme="dark"] .tenant-card {
-      background: rgba(26, 29, 35, 0.65);
-      border-color: rgba(148, 163, 184, 0.4);
-    }
-    .tenant-card__header {
-      display: flex;
-      justify-content: space-between;
-      gap: 0.8rem;
-      align-items: flex-start;
-      flex-wrap: wrap;
-    }
-    .tenant-card__projects {
-      font-weight: 600;
-      font-size: 0.9rem;
-      color: rgba(26, 29, 35, 0.8);
-    }
-    [data-theme="dark"] .tenant-card__projects {
-      color: rgba(226, 232, 240, 0.84);
-    }
-    .tenant-card__meta {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 0.75rem 1rem;
-      margin: 1rem 0 0;
-      padding: 0;
-    }
-    .tenant-card__meta-item {
       display: flex;
       flex-direction: column;
-      gap: 0.25rem;
+      gap: 0.75rem;
+      margin-bottom: 2rem;
     }
-    .tenant-card__meta dt {
-      margin: 0;
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: rgba(71, 85, 105, 0.85);
+    .tenant-card {
+      padding: 1rem 1.25rem;
+      border-radius: 0.7rem;
+      background: rgba(15, 23, 42, 0.04);
+      border: 1px solid rgba(148, 163, 184, 0.2);
     }
-    [data-theme="dark"] .tenant-card__meta dt {
-      color: rgba(226, 232, 240, 0.72);
+    [data-theme="dark"] .tenant-card {
+      background: rgba(148, 163, 184, 0.08);
+      border-color: rgba(148, 163, 184, 0.3);
     }
-    .tenant-card__meta dd {
-      margin: 0;
-      font-weight: 600;
-      line-height: 1.35;
+    .tenant-card__header {
+      margin-bottom: 0.5rem;
+    }
+    .tenant-card__meta {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.8rem;
+      color: #64748b;
+      margin: 0.5rem 0;
+    }
+    [data-theme="dark"] .tenant-card__meta {
+      color: rgba(148, 163, 184, 0.75);
+    }
+    .tenant-card__description {
+      font-size: 0.85rem;
+      color: rgba(71, 85, 105, 0.9);
+      margin: 0.5rem 0 0 0;
+    }
+    [data-theme="dark"] .tenant-card__description {
+      color: rgba(226, 232, 240, 0.8);
     }
     .tenant-card__actions {
       display: flex;
@@ -90,14 +70,6 @@
       gap: 0.75rem;
       margin-top: 1rem;
       align-items: center;
-    }
-    @media (max-width: 720px) {
-      .table-scroll.tenants-table {
-        display: none;
-      }
-      .tenants-card-list {
-        display: grid;
-      }
     }
   </style>
 {% endblock %}
@@ -110,56 +82,6 @@
     </div>
 
     <h2>Existing Tenants</h2>
-    <div class="table-scroll tenants-table">
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Description</th>
-            <th>Projects</th>
-            <th>Color</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for tenant, color_form in tenant_rows %}
-          <tr id="tenant-{{ tenant.id }}">
-            <td>
-              <span class="tenant-badge" style="--tenant-color: {{ tenant.color or default_tenant_color }}">
-                <span class="tenant-badge__swatch" aria-hidden="true"></span>
-                {{ tenant.name }}
-              </span>
-            </td>
-            <td>{{ tenant.description or "—" }}</td>
-            <td>{{ tenant.projects|length }}</td>
-            <td>
-              <form method="post" class="tenant-color-form">
-                {{ color_form.hidden_tag() }}
-                {{ color_form.tenant_id(value=tenant.id) }}
-                {{ color_form.color(class_="tenant-color-select") }}
-                {{ color_form.save(class_="secondary outline") }}
-              </form>
-            </td>
-            <td>
-              <form method="post" class="inline-form">
-                {{ delete_form.csrf_token }}
-                {{ delete_form.tenant_id(value=tenant.id) }}
-                {{ delete_form.submit(
-                  class_="link-button danger",
-                  value="Remove",
-                  onclick="return confirm('Remove tenant {{ tenant.name }} and all related data?')"
-                ) }}
-              </form>
-            </td>
-          </tr>
-          {% else %}
-          <tr>
-            <td colspan="5">No tenants yet.</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
 
     <div class="tenants-card-list">
       {% for tenant, color_form in tenant_rows %}
@@ -178,20 +100,15 @@
               <span class="tenant-badge__swatch" aria-hidden="true"></span>
               {{ tenant.name }}
             </span>
-            <span class="tenant-card__projects">
-              {{ tenant.projects|length }} project{{ '' if tenant.projects|length == 1 else 's' }}
-            </span>
           </header>
-          <dl class="tenant-card__meta">
-            <div class="tenant-card__meta-item">
-              <dt>Description</dt>
-              <dd>{{ tenant.description or "—" }}</dd>
-            </div>
-            <div class="tenant-card__meta-item">
-              <dt>Color</dt>
-              <dd>{{ tenant_color }}</dd>
-            </div>
-          </dl>
+          <div class="tenant-card__meta">
+            <span>{{ tenant.projects|length }} project{{ '' if tenant.projects|length == 1 else 's' }}</span>
+            <span>•</span>
+            <span>{{ tenant_color }}</span>
+          </div>
+          {% if tenant.description %}
+          <p class="tenant-card__description">{{ tenant.description }}</p>
+          {% endif %}
           <div class="tenant-card__actions">
             <form method="post" class="tenant-color-form">
               {{ color_form.hidden_tag() }}


### PR DESCRIPTION
## Summary
Convert Tenants admin page to thread-style card-based layout, matching SSH Keys and User Identities pages.

## Changes
- **Remove table layout entirely** (was dual layout with responsive switching)
- **Convert to single card-based column layout** for all screen sizes
- **Update card styling** to match thread-style pattern:
  - Compact spacing (0.75rem gap)
  - Thread-style backgrounds and borders
  - Border radius: 0.7rem
  - Padding: 1rem 1.25rem
- **Simplify metadata display** to inline badges (project count, color)
- **Show description** as standalone paragraph when present
- **Remove complex grid-based meta section**
- **Remove responsive media query** (no longer needed)

## Benefits
✅ Consistent design across all admin pages  
✅ Simpler, more maintainable code (-83 lines)  
✅ Better UX with unified experience  
✅ Compact, thread-style spacing  

## Testing
- Verified card layout on all screen sizes
- Tenant color badges display correctly
- Color picker and delete forms work as expected
- Deployed and tested on production

🤖 Generated with Claude Code