### PR TITLE
Feature: Convert Projects page to thread-style format

### DIFF
--- a/app/templates/admin/projects.html
+++ b/app/templates/admin/projects.html
@@ -5,7 +5,7 @@
   <style>
     .projects-layout {
       display: grid;
-      gap: 2rem;
+      gap: 1.5rem;
     }
     .projects-header {
       display: flex;
@@ -18,63 +18,58 @@
       margin: 0.25rem 0 0;
       max-width: 520px;
     }
-    .projects-table td code {
-      word-break: break-all;
-      font-size: 0.85rem;
-    }
     .projects-card-list {
-      display: none;
-      gap: 1rem;
-      margin-top: 1.25rem;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-bottom: 2rem;
     }
     .project-card {
-      border: 1px solid rgba(148, 163, 184, 0.3);
-      border-radius: 1rem;
-      padding: 1rem 1.2rem;
-      background: rgba(255, 255, 255, 0.86);
-      width: 100%;
+      padding: 1rem 1.25rem;
+      border-radius: 0.7rem;
+      background: rgba(15, 23, 42, 0.04);
+      border: 1px solid rgba(148, 163, 184, 0.2);
     }
     [data-theme="dark"] .project-card {
-      background: rgba(26, 29, 35, 0.65);
-      border-color: rgba(148, 163, 184, 0.4);
+      background: rgba(148, 163, 184, 0.08);
+      border-color: rgba(148, 163, 184, 0.3);
     }
     .project-card__header {
       display: flex;
       justify-content: space-between;
-      flex-wrap: wrap;
       gap: 0.75rem;
       align-items: flex-start;
+      margin-bottom: 0.5rem;
     }
     .project-card__header h3 {
       margin: 0;
       font-size: 1.05rem;
+      font-weight: 600;
+      color: var(--pico-color-slate-900);
+    }
+    [data-theme="dark"] .project-card__header h3 {
+      color: rgba(226, 232, 240, 0.95);
+    }
+    .project-card__repo {
+      font-family: 'Courier New', monospace;
+      font-size: 0.75rem;
+      color: #64748b;
+      margin: 0.25rem 0 0 0;
+      word-break: break-all;
+    }
+    [data-theme="dark"] .project-card__repo {
+      color: rgba(148, 163, 184, 0.75);
     }
     .project-card__meta {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 0.75rem 1.2rem;
-      margin: 1rem 0 0;
-      padding: 0;
-    }
-    .project-card__meta-item {
       display: flex;
-      flex-direction: column;
-      gap: 0.2rem;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.8rem;
+      color: #64748b;
+      margin: 0.5rem 0;
     }
-    .project-card__meta dt {
-      margin: 0;
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: rgba(71, 85, 105, 0.85);
-    }
-    [data-theme="dark"] .project-card__meta dt {
-      color: rgba(226, 232, 240, 0.72);
-    }
-    .project-card__meta dd {
-      margin: 0;
-      font-weight: 600;
+    [data-theme="dark"] .project-card__meta {
+      color: rgba(148, 163, 184, 0.75);
     }
     .project-card__actions {
       display: flex;
@@ -108,14 +103,6 @@
         grid-template-columns: 1fr;
       }
     }
-    @media (max-width: 720px) {
-      .table-scroll.projects-table {
-        display: none;
-      }
-      .projects-card-list {
-        display: grid;
-      }
-    }
   </style>
 {% endblock %}
 {% block content %}
@@ -126,50 +113,6 @@
         <h1>Projects</h1>
         <p class="text-muted">Manage synced repositories and their tenant ownership.</p>
       </div>
-    </div>
-    <div class="table-scroll projects-table">
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Tenant</th>
-            <th>Owner</th>
-            <th>Repository</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for project in projects %}
-          <tr>
-            <td>{{ project.name }}</td>
-            <td>
-              <span class="tenant-badge" style="--tenant-color: {{ project.tenant.color or default_tenant_color }}">
-                <span class="tenant-badge__swatch" aria-hidden="true"></span>
-                {{ project.tenant.name }}
-              </span>
-            </td>
-            <td>{{ project.owner.email }}</td>
-            <td><code>{{ project.repo_url }}</code></td>
-            <td>
-              <a href="{{ url_for('projects.project_detail', project_id=project.id) }}">Open</a>
-              <form method="post" class="inline-form">
-                {{ delete_form.csrf_token }}
-                {{ delete_form.project_id(value=project.id) }}
-                {{ delete_form.submit(
-                  class_="link-button danger",
-                  value="Remove",
-                  onclick="return confirm('Remove project {{ project.name }} and all related data?')"
-                ) }}
-              </form>
-            </td>
-          </tr>
-          {% else %}
-          <tr>
-            <td colspan="5">No projects configured.</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
     </div>
     <div class="projects-card-list">
       {% for project in projects %}
@@ -185,31 +128,22 @@
           <header class="project-card__header">
             <div>
               <h3>{{ project.name }}</h3>
-              <small class="text-muted">{{ project.repo_url }}</small>
+              <p class="project-card__repo">{{ project.repo_url }}</p>
             </div>
-            <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="secondary">
+            <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" role="button" class="secondary">
               Open
             </a>
           </header>
-          <dl class="project-card__meta">
-            <div class="project-card__meta-item">
-              <dt>Tenant</dt>
-              <dd>
-                <span class="tenant-badge" style="--tenant-color: {{ project.tenant.color or default_tenant_color }}">
-                  <span class="tenant-badge__swatch" aria-hidden="true"></span>
-                  {{ project.tenant.name }}
-                </span>
-              </dd>
-            </div>
-            <div class="project-card__meta-item">
-              <dt>Owner</dt>
-              <dd>{{ project.owner.email }}</dd>
-            </div>
-            <div class="project-card__meta-item">
-              <dt>Default Branch</dt>
-              <dd>{{ project.default_branch }}</dd>
-            </div>
-          </dl>
+          <div class="project-card__meta">
+            <span class="tenant-badge" style="--tenant-color: {{ project.tenant.color or default_tenant_color }}">
+              <span class="tenant-badge__swatch" aria-hidden="true"></span>
+              {{ project.tenant.name }}
+            </span>
+            <span>•</span>
+            <span>{{ project.owner.email }}</span>
+            <span>•</span>
+            <span>{{ project.default_branch }}</span>
+          </div>
           <div class="project-card__actions">
             <form method="post" class="inline-form">
               {{ delete_form.csrf_token }}


### PR DESCRIPTION
## Summary
Convert Projects admin page to thread-style card-based layout, matching other admin pages (Tenants, SSH Keys, User Identities).

## Changes
- **Remove table layout entirely** (was dual layout with responsive switching)
- **Convert to single card-based column layout** for all screen sizes
- **Update card styling** to match thread-style pattern:
  - Compact spacing (0.75rem gap)
  - Thread-style backgrounds and borders
  - Border radius: 0.7rem
  - Padding: 1rem 1.25rem
- **Simplify metadata display** to inline badges (tenant, owner, branch)
- **Show repo URL** as monospace text under project name
- **Remove complex grid-based meta section**
- **Remove responsive media query** for table hiding

## Benefits
✅ Consistent design across all admin pages  
✅ Simpler, more maintainable code (-66 lines)  
✅ Better UX with unified experience  
✅ Compact, thread-style spacing  

## Testing
- Verified card layout on all screen sizes
- Tenant badges and repo URLs display correctly
- Open and delete actions work as expected
- Deployed and tested on production

🤖 Generated with Claude Code