### PR TITLE
Fix: Add --tool parameter to commands and fix copy button (closes #130)

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2439,7 +2439,7 @@ def confirm_assisted_issue():
 
         # Pass CLI commands to success page
         cli_commands = {
-            "work_on_issue": f"aiops issues work {issue.id}",
+            "work_on_issue": f"aiops issues work {issue.id} --tool {ai_tool}",
             "get_details": f"aiops issues get {issue.id} --output json",
             "add_comment": f"aiops issues comment {issue.id} \"Your update\"",
             "close_issue": f"aiops issues close {issue.id}",

--- a/app/templates/admin/assisted_issue_success.html
+++ b/app/templates/admin/assisted_issue_success.html
@@ -177,7 +177,7 @@
           <span class="cli-command-label">Start AI Session (Primary Workflow)</span>
           <div class="cli-command-code">
             <code>{{ cli_commands.work_on_issue }}</code>
-            <button class="copy-button" onclick="copyToClipboard(this, '{{ cli_commands.work_on_issue }}')">Copy</button>
+            <button class="copy-button" data-copy-text="{{ cli_commands.work_on_issue }}">Copy</button>
           </div>
         </div>
 
@@ -185,7 +185,7 @@
           <span class="cli-command-label">View Issue Details</span>
           <div class="cli-command-code">
             <code>{{ cli_commands.get_details }}</code>
-            <button class="copy-button" onclick="copyToClipboard(this, '{{ cli_commands.get_details }}')">Copy</button>
+            <button class="copy-button" data-copy-text="{{ cli_commands.get_details }}">Copy</button>
           </div>
         </div>
 
@@ -193,7 +193,7 @@
           <span class="cli-command-label">Add Comment / Update Status</span>
           <div class="cli-command-code">
             <code>{{ cli_commands.add_comment }}</code>
-            <button class="copy-button" onclick="copyToClipboard(this, '{{ cli_commands.add_comment }}')">Copy</button>
+            <button class="copy-button" data-copy-text="{{ cli_commands.add_comment }}">Copy</button>
           </div>
         </div>
 
@@ -201,7 +201,7 @@
           <span class="cli-command-label">Close Issue (When Complete)</span>
           <div class="cli-command-code">
             <code>{{ cli_commands.close_issue }}</code>
-            <button class="copy-button" onclick="copyToClipboard(this, '{{ cli_commands.close_issue }}')">Copy</button>
+            <button class="copy-button" data-copy-text="{{ cli_commands.close_issue }}">Copy</button>
           </div>
         </div>
       </div>
@@ -222,23 +222,30 @@
 </div>
 
 <script>
-function copyToClipboard(button, text) {
-  navigator.clipboard.writeText(text).then(() => {
-    const originalText = button.textContent;
-    button.textContent = 'Copied!';
-    button.classList.add('copied');
+// Add click handlers to all copy buttons
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('.copy-button').forEach(button => {
+    button.addEventListener('click', function() {
+      const text = this.getAttribute('data-copy-text');
 
-    setTimeout(() => {
-      button.textContent = originalText;
-      button.classList.remove('copied');
-    }, 2000);
-  }).catch(err => {
-    console.error('Failed to copy:', err);
-    button.textContent = 'Failed';
-    setTimeout(() => {
-      button.textContent = 'Copy';
-    }, 2000);
+      navigator.clipboard.writeText(text).then(() => {
+        const originalText = this.textContent;
+        this.textContent = 'Copied!';
+        this.classList.add('copied');
+
+        setTimeout(() => {
+          this.textContent = originalText;
+          this.classList.remove('copied');
+        }, 2000);
+      }).catch(err => {
+        console.error('Failed to copy:', err);
+        this.textContent = 'Failed';
+        setTimeout(() => {
+          this.textContent = 'Copy';
+        }, 2000);
+      });
+    });
   });
-}
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
Fixes two issues in AI-assisted issue creation success page:

## Problem 1: Missing AI tool in generated commands
Previously, the generated command was:
```
aiops issues work 699
```

Now includes the selected AI tool:
```
aiops issues work 699 --tool claude
```

## Problem 2: Copy button not working
The copy buttons were broken due to Jinja template escaping issues when commands contained quotes.

**Root cause:** Inline onclick handlers like `onclick="copyToClipboard(this, '{{ command }}')"` break when the command contains quotes.

**Solution:** 
- Use data attributes instead: `data-copy-text="{{ command }}"`
- Attach event listeners via JavaScript after DOM loads
- Prevents escaping issues and handles special characters properly

## Changes
- **app/routes/admin.py (line 2442)**: Add `--tool {ai_tool}` to work_on_issue command
- **app/templates/admin/assisted_issue_success.html**:
  - Replace inline onclick with data-copy-text attributes
  - Rewrite JavaScript to use DOMContentLoaded event listeners
  - More robust error handling

## Testing
- Commands now include the --tool parameter
- Copy buttons work correctly even with quotes in commands
- Visual feedback ("Copied!") works as expected

Closes #130