### PR TITLE
Fix: Update Settings page card background to match thread-style

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -53,7 +53,7 @@
     padding: 1rem 1.25rem;
     border-radius: 0.7rem;
     border: 1px solid rgba(148, 163, 184, 0.2);
-    background: rgba(26, 29, 35, 0.04);
+    background: rgba(15, 23, 42, 0.04);
     width: 100%;
     box-sizing: border-box;
   }


### PR DESCRIPTION
## Summary
Correct the Settings page card background color to match the thread-style used across other admin pages for visual consistency.

## Changes
- **Light mode background:** `rgba(26, 29, 35, 0.04)` → `rgba(15, 23, 42, 0.04)`

## Benefits
✅ Visual consistency across all admin interface cards  
✅ Matches thread-style used in Projects, Tenants, SSH Keys, etc.  

## Testing
- Verified card background matches other admin pages
- Dark mode already correct (no changes needed)

🤖 Generated with Claude Code