### PR TITLE
Feature: Add internal and external issue IDs to web UI (closes #145)

### DIFF
--- a/app/templates/admin/assisted_issue_success.html
+++ b/app/templates/admin/assisted_issue_success.html
@@ -161,7 +161,7 @@
     </div>
 
     <div class="issue-details">
-      <p><strong>Issue:</strong> <a href="{{ issue.url }}" target="_blank">#{{ issue.external_id }}</a> - {{ issue.title }}</p>
+      <p><strong>Issue:</strong> <a href="{{ issue.url }}" target="_blank">#{{ issue.external_id }}</a> <span style="font-size: 0.9rem; color: #94a3b8;">(DB: {{ issue.id }})</span> - {{ issue.title }}</p>
       <p><strong>Project:</strong> {{ project.tenant.name }} / {{ project.name }}</p>
       <p><strong>AI Tool:</strong> {{ ai_tool }}</p>
       <p><strong>Context:</strong> AGENTS.override.md populated from {{ sources_msg }}</p>

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -957,7 +957,7 @@
             </a>
             <span class="separator">·</span>
           {% endif %}
-          <span class="issue-id">#{{ issue.external_id }}</span>
+          <span class="issue-id">#{{ issue.external_id }} <span class="text-muted" style="font-size: 0.85rem;">(DB: {{ issue.id }})</span></span>
         </div>
         <h3 class="issue-title">
           <a href="{{ url_for('admin.manage_issues') }}?issue_id={{ issue.id }}" class="issue-title-link">

--- a/app/templates/admin/issues.html
+++ b/app/templates/admin/issues.html
@@ -1113,6 +1113,7 @@
               {% else %}
                 {{ issue.external_id }}
               {% endif %}
+              <span class="text-muted" style="font-size: 0.75rem; margin-left: 0.5rem; font-weight: 400;">(DB: {{ issue.id }})</span>
             </h3>
             <p class="issue-card__title">{{ issue.title }}</p>
           </div>

--- a/app/templates/projects/detail.html
+++ b/app/templates/projects/detail.html
@@ -716,7 +716,7 @@
                     </div>
                   </div>
                   <div class="issue-card__meta">
-                    <small class="issue-card__id">{{ issue.external_id }}</small>
+                    <small class="issue-card__id">{{ issue.external_id }} <span class="text-muted">(DB: {{ issue.id }})</span></small>
                     {% if issue.updated_display %}
                       <small class="issue-card__timestamp">Updated {{ issue.updated_display }}</small>
                     {% endif %}


### PR DESCRIPTION
## Summary
Display both internal database IDs and external provider IDs throughout the web UI so users can easily reference them when using aiops CLI commands.

## Problem
- Users see external IDs (GitHub #123, GitLab !456, Jira PROJ-789) in the UI
- They need internal database IDs to use with aiops CLI commands
- Without both IDs visible, users have to search the database or use workarounds

## Solution
Added internal ID display alongside external ID in all issue display locations:
- Admin Issues page (main card header)
- Admin Dashboard (recent issues)
- Admin Assisted Issue Success page
- Project Detail page (project issues list)

Format: External ID (external tracker link) · (DB: internal ID)

## Changes
- `app/templates/admin/issues.html`: Added internal ID in card header
- `app/templates/admin/dashboard.html`: Added internal ID next to external ID
- `app/templates/admin/assisted_issue_success.html`: Added internal ID in issue details
- `app/templates/projects/detail.html`: Added internal ID in issue list

## Benefits
✅ Users can see both IDs at a glance
✅ Easier to reference issues in aiops CLI commands
✅ Consistent display across all issue UI pages
✅ Non-breaking change (purely additive)

## Testing
- Template rendering tested
- Visual layout maintained
- Both IDs visible in UI