### PR TITLE
Improvement: Reduce spacing between collapsed tenant group headers

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -938,7 +938,7 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    margin: 1.5rem 0 1rem;
+    margin: 0.25rem 0;
     padding: 0.75rem;
     border-bottom: 2px solid #e2e8f0;
     background: transparent;


### PR DESCRIPTION
## Summary
Significantly reduce margins between tenant group headers for a much tighter, more compact collapsed view. 

## Changes
- Tenant group header margin: 1.5rem 0 1rem → **0.25rem 0**
- Result: Minimal spacing (only 4px) between collapsed headers
- First header still starts at top

## Before vs After
**Before:** Floads and IWF headers have large gap  
**After:** Headers sit right next to each other

## Benefits
✨ Much more compact collapsed view
✨ Better use of vertical space
✨ Cleaner dashboard appearance

🤖 Generated with Claude Code