### PR TITLE
Fix: Filter out closed issues from pinned list on dashboard

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -964,6 +964,7 @@ def dashboard():
         PinnedIssue.query.filter_by(user_id=_current_user_obj().id)
         .join(ExternalIssue)
         .join(ProjectIntegration)
+        .filter(ExternalIssue.status != 'closed')
         .options(
             selectinload(PinnedIssue.issue)
             .selectinload(ExternalIssue.project_integration)


### PR DESCRIPTION
## Summary
Closed issues should not appear in the pinned issues section on the dashboard. This fix filters them out automatically.

## Problem
Even after closing issues, they still appeared in the pinned section if they were pinned earlier.

## Solution
Add a filter to the pinned issues query to only show open issues:
`ExternalIssue.status != 'closed'`

## Result
✅ Dashboard pinned section only shows open/active issues
✅ Closed issues automatically hidden even if pinned
✅ Cleaner dashboard state

## Testing
- Dashboard tests pass (1/1)
- No breaking changes

🤖 Generated with Claude Code