### PR TITLE
Revert: Remove closed issues filter from pinned list

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -964,7 +964,6 @@ def dashboard():
         PinnedIssue.query.filter_by(user_id=_current_user_obj().id)
         .join(ExternalIssue)
         .join(ProjectIntegration)
-        .filter(ExternalIssue.status != 'closed')
         .options(
             selectinload(PinnedIssue.issue)
             .selectinload(ExternalIssue.project_integration)


### PR DESCRIPTION
## Summary
Revert the filter that hid closed issues from the pinned list. Users want to see closed issues in their pinned list, and can manually clean them up when needed.

## Changes
- Removes filter: ExternalIssue.status != 'closed'
- Pinned list now shows open AND closed issues
- Users can manually unpin closed issues when desired

## Rationale
Users prefer to see closed issues in the pinned list for visibility, and can clean them up manually via unpin button when they want.

🤖 Generated with Claude Code